### PR TITLE
Enemy ai bug fixes & tweaks

### DIFF
--- a/Assets/Prefabs/Guard.prefab
+++ b/Assets/Prefabs/Guard.prefab
@@ -194,7 +194,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6ebfc57171b24ee2878be79fb2d5cba5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  movementSpeed: 12
+  movementSpeed: 10
   flipTime: 0.2
   qteTimeLimit: 4
   timeLostPerEncounter: 0.5
@@ -225,12 +225,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   quickDetection: 0
-  maxDistanceModifier: 3
+  maxDistanceModifier: 2
   minDistanceModifier: 0.25
-  normalViewAngle: 45
-  alertedViewAngle: 60
-  normalViewDistance: 8
-  alertedViewDistance: 12
+  normalViewAngle: 60
+  alertedViewAngle: 80
+  normalViewDistance: 9
+  alertedViewDistance: 14
   targetLayer:
     serializedVersion: 2
     m_Bits: 8
@@ -251,10 +251,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   quickDetection: 1
-  maxDistanceModifier: 3
+  maxDistanceModifier: 2
   minDistanceModifier: 0.25
-  normalViewRadius: 1.75
-  alertedViewRadius: 4
+  normalViewRadius: 3
+  alertedViewRadius: 5
   targetLayer:
     serializedVersion: 2
     m_Bits: 8
@@ -275,6 +275,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50ac8fc84a1404a5788f5727f2c14f89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  quickDetectModifier: 10
 --- !u!1 &2924834700768163338
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Guard.prefab
+++ b/Assets/Prefabs/Guard.prefab
@@ -253,7 +253,7 @@ MonoBehaviour:
   quickDetection: 1
   maxDistanceModifier: 3
   minDistanceModifier: 0.25
-  normalViewRadius: 1
+  normalViewRadius: 1.75
   alertedViewRadius: 4
   targetLayer:
     serializedVersion: 2

--- a/Assets/Scenes/enemyTestScene.unity
+++ b/Assets/Scenes/enemyTestScene.unity
@@ -502,6 +502,10 @@ PrefabInstance:
       propertyPath: quickDetectModifier
       value: 10
       objectReference: {fileID: 0}
+    - target: {fileID: 6226547477544165859, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: movementSpeed
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
       propertyPath: m_LocalPosition.x
       value: 12.25

--- a/Assets/Scenes/enemyTestScene.unity
+++ b/Assets/Scenes/enemyTestScene.unity
@@ -122,6 +122,128 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &31132967
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 768295214414954276, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_Name
+      value: Guard (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34.66
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 277e91905163040f08033e377006c417, type: 3}
+--- !u!1001 &82229775
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 768295214414954276, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_Name
+      value: Guard (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6483612513045490718, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: leftPatrolDistance
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6483612513045490718, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: rightPatrolDistance
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 277e91905163040f08033e377006c417, type: 3}
 --- !u!1001 &367894350
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -490,6 +612,63 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6a70e191e0c0142bea6a2e06cf9c8a39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &584542424
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 768295214414954276, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_Name
+      value: Guard (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 57.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 277e91905163040f08033e377006c417, type: 3}
 --- !u!1 &867319601
 GameObject:
   m_ObjectHideFlags: 0
@@ -1268,6 +1447,63 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &2110058459
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 768295214414954276, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_Name
+      value: Guard (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 277e91905163040f08033e377006c417, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1278,3 +1514,7 @@ SceneRoots:
   - {fileID: 1347805688}
   - {fileID: 1906975198}
   - {fileID: 1502943119}
+  - {fileID: 82229775}
+  - {fileID: 584542424}
+  - {fileID: 2110058459}
+  - {fileID: 31132967}

--- a/Assets/Scenes/enemyTestScene.unity
+++ b/Assets/Scenes/enemyTestScene.unity
@@ -486,87 +486,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6a70e191e0c0142bea6a2e06cf9c8a39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &747953504
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 768295214414954276, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_Name
-      value: Guard
-      objectReference: {fileID: 0}
-    - target: {fileID: 5214291992342817127, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: quickDetectModifier
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 6226547477544165859, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: movementSpeed
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 12.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -3.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9035393051115882241, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: normalViewAngle
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 9035393051115882241, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: alertedViewAngle
-      value: 80
-      objectReference: {fileID: 0}
-    - target: {fileID: 9035393051115882241, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: normalViewDistance
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 9035393051115882241, guid: 277e91905163040f08033e377006c417, type: 3}
-      propertyPath: alertedViewDistance
-      value: 14
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 277e91905163040f08033e377006c417, type: 3}
 --- !u!1 &867319601
 GameObject:
   m_ObjectHideFlags: 0
@@ -931,6 +850,63 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &1502943119
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 768295214414954276, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_Name
+      value: Guard
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 277e91905163040f08033e377006c417, type: 3}
 --- !u!1001 &1906975198
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1297,4 +1273,4 @@ SceneRoots:
   - {fileID: 367894350}
   - {fileID: 1347805688}
   - {fileID: 1906975198}
-  - {fileID: 747953504}
+  - {fileID: 1502943119}

--- a/Assets/Scenes/enemyTestScene.unity
+++ b/Assets/Scenes/enemyTestScene.unity
@@ -498,6 +498,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Guard
       objectReference: {fileID: 0}
+    - target: {fileID: 5214291992342817127, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: quickDetectModifier
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
       propertyPath: m_LocalPosition.x
       value: 12.25
@@ -537,6 +541,22 @@ PrefabInstance:
     - target: {fileID: 7493615964463022480, guid: 277e91905163040f08033e377006c417, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9035393051115882241, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: normalViewAngle
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 9035393051115882241, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: alertedViewAngle
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 9035393051115882241, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: normalViewDistance
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 9035393051115882241, guid: 277e91905163040f08033e377006c417, type: 3}
+      propertyPath: alertedViewDistance
+      value: 14
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/enemyTestScene.unity
+++ b/Assets/Scenes/enemyTestScene.unity
@@ -155,6 +155,10 @@ PrefabInstance:
       value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 2204501328560629039, guid: c6f9bd836282842348fab8839a2de283, type: 3}
+      propertyPath: falseTriggerCooldown
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2204501328560629039, guid: c6f9bd836282842348fab8839a2de283, type: 3}
       propertyPath: playerMovementController
       value: 
       objectReference: {fileID: 1906975199}

--- a/Assets/_Scripts/Card/Card.cs
+++ b/Assets/_Scripts/Card/Card.cs
@@ -150,7 +150,7 @@ namespace _Scripts.Card
         private void ActivateFalseTrigger()
         {
             if (CardManager.Instance.falseTriggerOnCooldown) return;
-            
+
             var colliders = Physics2D.OverlapCircleAll(transform.position, falseTriggerRadius, LayerMask.GetMask("Enemy"));
 
             foreach (Collider2D col in colliders)
@@ -165,7 +165,7 @@ namespace _Scripts.Card
                 }
             }
 
-            StartCoroutine(CardManager.Instance.FalseTriggerCooldown());
+            CardManager.Instance.ActivateFalseTriggerCooldown();
             DestroyCard();
         }
 

--- a/Assets/_Scripts/Card/CardManager.cs
+++ b/Assets/_Scripts/Card/CardManager.cs
@@ -178,8 +178,19 @@ namespace _Scripts.Card
                 Teleport.Invoke(Card.Instance.transform.position);
             }
         }
+
+        /*
+         * Coroutines are tied to the MonoBehavior they are called from
+         * so this function is needed to call the cooldown coroutine from the card
+         * that gets destroyed immediately after
+         */
         
-        public IEnumerator FalseTriggerCooldown()
+        public void ActivateFalseTriggerCooldown()
+        {
+            if (falseTriggerOnCooldown) return;
+            StartCoroutine(FalseTriggerCooldown());
+        }
+        private IEnumerator FalseTriggerCooldown()
         {
             falseTriggerOnCooldown = true;
             yield return new WaitForSeconds(falseTriggerCooldown);

--- a/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
+++ b/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using _Scripts.Card;
 using _Scripts.Enemies.ViewTypes;
 using _Scripts.Player;
 using UnityEngine;
@@ -143,6 +144,9 @@ namespace _Scripts.Enemies.AggroTypes
             var timeElapsed = 0f;
 
             var playerRb = PlayerVariables.Instance.gameObject.GetComponent<Rigidbody2D>();
+            
+            // Make sure the card throw arrow isn't active
+            HandleCardStanceArrow.Instance.DestroyDirectionalArrow();
             
             // Local method to handle the false trigger input
             void OnFalseTriggerHandler() => counter++;

--- a/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
+++ b/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
@@ -153,6 +153,12 @@ namespace _Scripts.Enemies.AggroTypes
             {
                 while (timeElapsed < qteTimeLimit && counter < counterGoal)
                 {
+                    // Break out of the QTE if the enemy gets hit with a card
+                    if (_enemyStateManager.state == EnemyState.Disabled)
+                    {
+                        _playerStateManager.SetState(PlayerState.Idle);
+                        yield return null;
+                    }
                     // Stop any movement from the guard or player
                     _rb.velocity = Vector2.zero;
                     playerRb.velocity = Vector2.zero;

--- a/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
+++ b/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
@@ -134,7 +134,6 @@ namespace _Scripts.Enemies.AggroTypes
         // Flip the entity's sprite by inverting the X scaling
         private IEnumerator FlipLocalScale(Vector2 location)
         {
-            Debug.Log("Flip");
             yield return new WaitForSeconds(flipTime);
             _settings.FlipLocalScale();
             MoveTo(location);

--- a/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
+++ b/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
@@ -157,7 +157,8 @@ namespace _Scripts.Enemies.AggroTypes
                     if (_enemyStateManager.state == EnemyState.Disabled)
                     {
                         _playerStateManager.SetState(PlayerState.Idle);
-                        yield return null;
+                        StopCoroutine(StartQuicktimeEvent());
+                        yield break;
                     }
                     // Stop any movement from the guard or player
                     _rb.velocity = Vector2.zero;

--- a/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
+++ b/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
@@ -5,7 +5,6 @@ using _Scripts.Enemies.ViewTypes;
 using _Scripts.Player;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.Serialization;
 
 namespace _Scripts.Enemies.AggroTypes
 {
@@ -19,7 +18,9 @@ namespace _Scripts.Enemies.AggroTypes
         [SerializeField] private float timeLostPerEncounter = 0.5f;
         [SerializeField] private int counterGoal = 15;
         private bool _hasExecuted = false;
-        private bool _isFlipping = false;
+        
+        private float _flipCooldown = 0.8f;
+        private float _lastFlipTime = -Mathf.Infinity; // for flip cooldown to prevent multiple flips happening really fast
 
         private Vector2 _targetPosition;
         private Vector2 _lastKnownPosition;
@@ -31,7 +32,7 @@ namespace _Scripts.Enemies.AggroTypes
         private Rigidbody2D _rb;
 
         public Vector2 LastKnownPosition() => _lastKnownPosition;
-        
+
         private void Awake()
         {
             _viewTypes = GetComponents<IViewType>();
@@ -43,7 +44,6 @@ namespace _Scripts.Enemies.AggroTypes
 
         private void Update()
         {
-            // TODO: Check for player distance and call QTE from there
             Movement();
         }
 
@@ -54,7 +54,8 @@ namespace _Scripts.Enemies.AggroTypes
         public void Movement()
         {
             if (_enemyStateManager.state != EnemyState.Aggro) return;
-            // if NoPlayerDetected is called call GoToLastKnownLocation and return;
+
+            // Check if player is detected
             var noPlayerDetected = true;
             foreach (var viewType in _viewTypes)
             {
@@ -64,7 +65,7 @@ namespace _Scripts.Enemies.AggroTypes
                     break;
                 }
             }
-            
+
             if (noPlayerDetected)
             {
                 if (!_checkingLastKnownLocation)
@@ -84,28 +85,32 @@ namespace _Scripts.Enemies.AggroTypes
             }
 
             var targetPos = (Vector2)PlayerVariables.Instance.transform.position;
-            
+
+            var timeSinceLastFlip = Time.time - _lastFlipTime;
+
             // If the enemy is already facing the target move to it
             if ((_settings.isFacingRight && targetPos.x > transform.position.x)
                 || (!_settings.isFacingRight && targetPos.x < transform.position.x))
             {
                 MoveTo(targetPos);
             }
-            // Otherwise, turn around then move it it
-            else if (!_isFlipping)
+            // Otherwise check cooldown before flipping
+            else if (timeSinceLastFlip >= _flipCooldown)
             {
+                _lastFlipTime = Time.time; // Update last flip time
                 StartCoroutine(FlipLocalScale(targetPos));
+            }
+            else
+            {
+                _rb.velocity = Vector2.Lerp(_rb.velocity, Vector2.zero, Time.deltaTime);
             }
         }
 
         private void GoToLastKnownLocation(Vector2 location)
         {
             _checkingLastKnownLocation = true;
-            // move to target location 
             MoveTo(location);
-           
-            
-            // switch to Searching state
+
             if (_enemyStateManager.state == EnemyState.Aggro)
             {
                 _enemyStateManager.SetState(EnemyState.Searching);
@@ -122,25 +127,19 @@ namespace _Scripts.Enemies.AggroTypes
             // Checking if the target position has been reached
             if ((!_settings.isFacingRight || !(transform.position.x >= location.x))
                 && (_settings.isFacingRight || !(transform.position.x <= location.x))) return;
-        
+
             _rb.velocity = new Vector2(0, _rb.velocity.y);
         }
-        
+
         // Flip the entity's sprite by inverting the X scaling
         private IEnumerator FlipLocalScale(Vector2 location)
         {
-            _isFlipping = true;
+            Debug.Log("Flip");
             yield return new WaitForSeconds(flipTime);
-            // I don't know why the transformCopy needs to exist but Unity yelled at me when I didn't have it so here it sits..
-            var transformCopy = transform;
-            var localScale = transformCopy.localScale;
-            localScale.x *= -1;
-            transformCopy.localScale = localScale;
-            
-            _isFlipping = false;
+            _settings.FlipLocalScale();
             MoveTo(location);
         }
-
+        
         // Modified grapple coroutine from Don't Move
         private IEnumerator StartQuicktimeEvent()
         {

--- a/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
+++ b/Assets/_Scripts/Enemies/AggroTypes/DefaultAggro.cs
@@ -75,7 +75,10 @@ namespace _Scripts.Enemies.AggroTypes
                 }
                 else
                 {
-                    _enemyStateManager.SetState(EnemyState.Searching);
+                    if (_enemyStateManager.state == EnemyState.Aggro)
+                    {
+                        _enemyStateManager.SetState(EnemyState.Searching);
+                    }
                 }
                 return;
             }
@@ -100,9 +103,13 @@ namespace _Scripts.Enemies.AggroTypes
             _checkingLastKnownLocation = true;
             // move to target location 
             MoveTo(location);
+           
             
             // switch to Searching state
-            _enemyStateManager.SetState(EnemyState.Searching);
+            if (_enemyStateManager.state == EnemyState.Aggro)
+            {
+                _enemyStateManager.SetState(EnemyState.Searching);
+            }
         }
 
         private void MoveTo(Vector2 location)

--- a/Assets/_Scripts/Enemies/DetectionTimer.cs
+++ b/Assets/_Scripts/Enemies/DetectionTimer.cs
@@ -7,6 +7,7 @@ namespace _Scripts.Enemies
 {
     public class DetectionTimer : MonoBehaviour
     {
+        [SerializeField] private float quickDetectModifier = 5f;
         private float _detectionTimer = 0f;
         
         private EnemySettings _settings;
@@ -51,7 +52,7 @@ namespace _Scripts.Enemies
             // Debug.Log("Modifier:" + distanceModifier);
 
             if (!(_detectionTimer >= Mathf.Abs(_settings.baseDetectionTime)) && !quickDetect) return;
-            if (!(_detectionTimer >= Mathf.Abs(_settings.baseDetectionTime / 4f)) && quickDetect) return;
+            if (!(_detectionTimer >= Mathf.Abs(_settings.baseDetectionTime / quickDetectModifier)) && quickDetect) return;
             
             // Switch to the agro state after filling detection meter
             _stateManager.SetState(EnemyState.Aggro);

--- a/Assets/_Scripts/Enemies/EnemyPatrolling.cs
+++ b/Assets/_Scripts/Enemies/EnemyPatrolling.cs
@@ -68,8 +68,12 @@ namespace _Scripts.Enemies
         {
             HandleGroundDetection();
             HandleGravity();
-
-            if ((_stateManager.state is EnemyState.Patrolling or EnemyState.Detecting) && !_isWaiting)
+            
+            if (_stateManager.state == EnemyState.Disabled)
+            {
+                _rb.velocity = new Vector2(0f, _rb.velocity.y);
+            }
+            else if ((_stateManager.state is EnemyState.Patrolling or EnemyState.Detecting) && !_isWaiting)
             {
                 MoveTowardsTarget();
             }
@@ -106,6 +110,7 @@ namespace _Scripts.Enemies
         
         private void ReturnToPatrolPosition()
         {
+
             var distanceToOrigin = _originPosition.x - transform.position.x;
             var direction = distanceToOrigin > 0 ? 1f : -1f;
 

--- a/Assets/_Scripts/Enemies/EnemyPatrolling.cs
+++ b/Assets/_Scripts/Enemies/EnemyPatrolling.cs
@@ -170,7 +170,7 @@ namespace _Scripts.Enemies
         }
 
         // Gizmos of the patrol distance and ground detection ray visible in the editor
-        private void OnDrawGizmosSelected()
+        private void OnDrawGizmos()
         {
             Gizmos.color = patrolPathColor;
 

--- a/Assets/_Scripts/Enemies/EnemyStateManager.cs
+++ b/Assets/_Scripts/Enemies/EnemyStateManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using _Scripts.Enemies.ViewTypes;
 using TMPro;
 using UnityEngine;
@@ -11,6 +12,7 @@ namespace _Scripts.Enemies
         public EnemyState state;
         private IViewType[] _viewTypes;
         private Rigidbody2D _rb;
+        private bool _waiting;
         public void SetState(EnemyState newState)
         {
             this.state = newState;
@@ -98,7 +100,7 @@ namespace _Scripts.Enemies
                 case EnemyState.Patrolling:
                     return;
                 case EnemyState.Detecting:
-                    state = EnemyState.Patrolling;
+                    if (!_waiting) StartCoroutine(WaitBeforeSwitchingBackToPatrol());
                     return;
                 case EnemyState.Aggro:
                     return;
@@ -107,6 +109,24 @@ namespace _Scripts.Enemies
                 case EnemyState.Stunned:
                     return;
             }
+        }
+
+        /*
+         * Called if the enemy is detecting the player and they step out of view.
+         * Instead of immediately returning to their patrol state the guard should keep looking in direction
+         * of the player's light sighting for a short time before returning.
+         */
+        private IEnumerator WaitBeforeSwitchingBackToPatrol()
+        {
+            _waiting = true;
+            yield return new WaitForSeconds(2);
+
+            if (state == EnemyState.Detecting)
+            {
+                state = EnemyState.Patrolling;
+            }
+
+            _waiting = false;
         }
 
         private void OnCollisionEnter2D(Collision2D col)

--- a/Assets/_Scripts/Enemies/EnemyStateManager.cs
+++ b/Assets/_Scripts/Enemies/EnemyStateManager.cs
@@ -135,6 +135,8 @@ namespace _Scripts.Enemies
             {
                 state = EnemyState.Disabled;
                 // TODO: Maybe destroy card? 
+                var card =  col.gameObject.GetComponent<Card.Card>();
+                card.DestroyCard();
             }
 
             // If the player touches an alive and un-stunned guard it should aggro them immediately 

--- a/Assets/_Scripts/Enemies/EnemyStateManager.cs
+++ b/Assets/_Scripts/Enemies/EnemyStateManager.cs
@@ -1,5 +1,6 @@
 using System;
 using _Scripts.Enemies.ViewTypes;
+using TMPro;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -9,6 +10,7 @@ namespace _Scripts.Enemies
     {
         public EnemyState state;
         private IViewType[] _viewTypes;
+        private Rigidbody2D _rb;
         public void SetState(EnemyState newState)
         {
             this.state = newState;
@@ -17,6 +19,7 @@ namespace _Scripts.Enemies
         private void Awake()
         {
             _viewTypes = GetComponents<IViewType>();
+            _rb = GetComponent<Rigidbody2D>();
         }
 
         private void OnEnable()
@@ -34,6 +37,14 @@ namespace _Scripts.Enemies
             {
                 viewType.PlayerDetected -= HandlePlayerSighting;
                 viewType.NoPlayerDetected -= HandleNoPlayerSighting;
+            }
+        }
+
+        private void Update()
+        {
+            if (state == EnemyState.Disabled)
+            {
+                _rb.velocity = Vector2.zero;
             }
         }
 

--- a/Assets/_Scripts/Enemies/ViewTypes/ConeView.cs
+++ b/Assets/_Scripts/Enemies/ViewTypes/ConeView.cs
@@ -132,7 +132,7 @@ namespace _Scripts.Enemies.ViewTypes
              _viewAngle *= modifier;
         }
 
-        private void OnDrawGizmosSelected()
+        private void OnDrawGizmos()
         {
             if (_settings == null) InitializeSettings();
             

--- a/Assets/_Scripts/Enemies/ViewTypes/SphereView.cs
+++ b/Assets/_Scripts/Enemies/ViewTypes/SphereView.cs
@@ -123,7 +123,7 @@ namespace _Scripts.Enemies.ViewTypes
             alertedViewRadius = _baseAlertedViewRadius * modifier;
         }
 
-        private void OnDrawGizmosSelected()
+        private void OnDrawGizmos()
         {
             if (_settings == null) InitializeSettings();
 


### PR DESCRIPTION
- Added several state checks throughout the scripts to ensure the enemy is in the correct state before applying any behavior.
- Added a delay between the switch from detecting to patrolling so the enemy doesn't immediately turn around if they lose sight of the player
- Fixed QTE interaction with card throws
- Fixed directional indicator appearing in QTE
- Fixed turnaround behavior while in Aggro state
- Stopped all motion while in Disabled state
- Fixed FalseTrigger getting stuck on cd, it was just easiest to do it here instead of in the FalseTrigger branch
