### PR TITLE
cancel active card & minor directional arrow fix

### DIFF
--- a/Assets/PlayerInputActions.cs
+++ b/Assets/PlayerInputActions.cs
@@ -53,6 +53,15 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""CancelCardThrow"",
+                    ""type"": ""Button"",
+                    ""id"": ""8166bec4-7ba7-44c4-bef2-724a6c89bd4c"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -93,28 +102,6 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
                     ""name"": """",
                     ""id"": ""137f7767-d2ff-43d5-bd57-f2a8ec45bd6d"",
                     ""path"": ""<Keyboard>/1"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""Throw"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
-                    ""id"": ""9eee67ae-915c-46f1-bc28-498858f81909"",
-                    ""path"": ""<XInputController>/rightShoulder"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""Throw"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
-                    ""id"": ""1919dbea-37e2-4aef-9ba8-22afaae30a7d"",
-                    ""path"": ""<DualShockGamepad>/rightShoulder"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
@@ -198,6 +185,39 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
                     ""action"": ""FalseTrigger"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""32fa6955-821d-4a99-974b-7e4a980573b3"",
+                    ""path"": ""<Keyboard>/3"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""CancelCardThrow"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""faa2313c-1b4e-4943-8bc9-d76bf8cce0e6"",
+                    ""path"": ""<DualShockGamepad>/rightShoulder"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""CancelCardThrow"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""e4d764c9-8751-43bf-89e8-dfa32dee3289"",
+                    ""path"": ""<XInputController>/rightShoulder"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""CancelCardThrow"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
                 }
             ]
         }
@@ -209,6 +229,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
         m_Player_Aim = m_Player.FindAction("Aim", throwIfNotFound: true);
         m_Player_Throw = m_Player.FindAction("Throw", throwIfNotFound: true);
         m_Player_FalseTrigger = m_Player.FindAction("FalseTrigger", throwIfNotFound: true);
+        m_Player_CancelCardThrow = m_Player.FindAction("CancelCardThrow", throwIfNotFound: true);
     }
 
     public void Dispose()
@@ -273,6 +294,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
     private readonly InputAction m_Player_Aim;
     private readonly InputAction m_Player_Throw;
     private readonly InputAction m_Player_FalseTrigger;
+    private readonly InputAction m_Player_CancelCardThrow;
     public struct PlayerActions
     {
         private @PlayerInputActions m_Wrapper;
@@ -280,6 +302,7 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
         public InputAction @Aim => m_Wrapper.m_Player_Aim;
         public InputAction @Throw => m_Wrapper.m_Player_Throw;
         public InputAction @FalseTrigger => m_Wrapper.m_Player_FalseTrigger;
+        public InputAction @CancelCardThrow => m_Wrapper.m_Player_CancelCardThrow;
         public InputActionMap Get() { return m_Wrapper.m_Player; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -298,6 +321,9 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
             @FalseTrigger.started += instance.OnFalseTrigger;
             @FalseTrigger.performed += instance.OnFalseTrigger;
             @FalseTrigger.canceled += instance.OnFalseTrigger;
+            @CancelCardThrow.started += instance.OnCancelCardThrow;
+            @CancelCardThrow.performed += instance.OnCancelCardThrow;
+            @CancelCardThrow.canceled += instance.OnCancelCardThrow;
         }
 
         private void UnregisterCallbacks(IPlayerActions instance)
@@ -311,6 +337,9 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
             @FalseTrigger.started -= instance.OnFalseTrigger;
             @FalseTrigger.performed -= instance.OnFalseTrigger;
             @FalseTrigger.canceled -= instance.OnFalseTrigger;
+            @CancelCardThrow.started -= instance.OnCancelCardThrow;
+            @CancelCardThrow.performed -= instance.OnCancelCardThrow;
+            @CancelCardThrow.canceled -= instance.OnCancelCardThrow;
         }
 
         public void RemoveCallbacks(IPlayerActions instance)
@@ -333,5 +362,6 @@ public partial class @PlayerInputActions: IInputActionCollection2, IDisposable
         void OnAim(InputAction.CallbackContext context);
         void OnThrow(InputAction.CallbackContext context);
         void OnFalseTrigger(InputAction.CallbackContext context);
+        void OnCancelCardThrow(InputAction.CallbackContext context);
     }
 }

--- a/Assets/PlayerInputActions.inputactions
+++ b/Assets/PlayerInputActions.inputactions
@@ -31,6 +31,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "CancelCardThrow",
+                    "type": "Button",
+                    "id": "8166bec4-7ba7-44c4-bef2-724a6c89bd4c",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -71,28 +80,6 @@
                     "name": "",
                     "id": "137f7767-d2ff-43d5-bd57-f2a8ec45bd6d",
                     "path": "<Keyboard>/1",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Throw",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "9eee67ae-915c-46f1-bc28-498858f81909",
-                    "path": "<XInputController>/rightShoulder",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Throw",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "1919dbea-37e2-4aef-9ba8-22afaae30a7d",
-                    "path": "<DualShockGamepad>/rightShoulder",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -174,6 +161,39 @@
                     "processors": "",
                     "groups": "",
                     "action": "FalseTrigger",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "32fa6955-821d-4a99-974b-7e4a980573b3",
+                    "path": "<Keyboard>/3",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CancelCardThrow",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "faa2313c-1b4e-4943-8bc9-d76bf8cce0e6",
+                    "path": "<DualShockGamepad>/rightShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CancelCardThrow",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e4d764c9-8751-43bf-89e8-dfa32dee3289",
+                    "path": "<XInputController>/rightShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CancelCardThrow",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/_Scripts/Card/Card.cs
+++ b/Assets/_Scripts/Card/Card.cs
@@ -91,6 +91,7 @@ namespace _Scripts.Card
         {
             // TODO: InputHandler.Instance.OnEnterCardStance += DestroyCard;
             InputHandler.Instance.OnFalseTrigger += ActivateFalseTrigger;
+            InputHandler.Instance.OnCancelActiveCard += DestroyCard;
             CardManager.Instance.Teleport += CatchTeleport;
         }
 
@@ -99,6 +100,7 @@ namespace _Scripts.Card
         {
             // TODO: InputHandler.Instance.OnEnterCardStance -= DestroyCard;
             InputHandler.Instance.OnFalseTrigger -= ActivateFalseTrigger;
+            InputHandler.Instance.OnCancelActiveCard -= DestroyCard;
             CardManager.Instance.Teleport -= CatchTeleport;
         }
 

--- a/Assets/_Scripts/Card/HandleCardStanceArrow.cs
+++ b/Assets/_Scripts/Card/HandleCardStanceArrow.cs
@@ -44,18 +44,12 @@ namespace _Scripts.Card
                 Quaternion.identity,
                 PlayerVariables.Instance.transform
             );
-            
-            //TODO: Fix the horizontal starting position
-            // Calculate the starting rotation angle based on the direction
-            // var angle = (PlayerVariables.Instance.isFacingRight) ? 90f : -90f; // Left: 90°, Right: -90°
-            // Debug.Log(angle);
-            // _directionalArrowInstance.transform.rotation = Quaternion.Euler(0, 0, angle);
         }
 
         private void Update()
         {
-            // if (_directionalArrowInstance == null) return;
-            // UpdateArrow();
+            if (CardManager.Instance.IsCardInScene() && _directionalArrowInstance != null)
+                DestroyDirectionalArrow();
         }
 
         private void OnEnable()
@@ -65,13 +59,6 @@ namespace _Scripts.Card
 
         private void UpdateArrow(Vector2 directions)
         {
-            // Get the joystick input (currently left joystick)
-            // var horizontal = Input.GetAxis("Horizontal");
-            // var vertical = Input.GetAxis("Vertical");
-
-            // var inputDirection = new Vector2(horizontal, vertical);
-            
-            
             currentDirection = directions;
             // Debug.Log(currentDirection);
 
@@ -99,7 +86,6 @@ namespace _Scripts.Card
             _directionalArrowInstance.transform.rotation = Quaternion.Euler(0, 0, angleDeg - 90f);
         }
 
-        // Destroys the directional arrow when the player leaves card stance or throws a card TODO: link up card throwing
         public void DestroyDirectionalArrow()
         {
             if (_directionalArrowInstance == null) return;

--- a/Assets/_Scripts/InputHandler.cs
+++ b/Assets/_Scripts/InputHandler.cs
@@ -42,6 +42,7 @@ namespace _Scripts
             _inputActions.Player.Aim.canceled += OnLookCanceled;
 
             _inputActions.Player.Throw.performed += OnThrowPerformed;
+            _inputActions.Player.CancelCardThrow.performed += OnCancelCardThrow;
             _inputActions.Player.FalseTrigger.performed += OnFalseTriggerPerformed;
         }
 
@@ -51,6 +52,7 @@ namespace _Scripts
             _inputActions.Player.Aim.canceled -= OnLookCanceled;
 
             _inputActions.Player.Throw.performed -= OnThrowPerformed;
+            _inputActions.Player.CancelCardThrow.performed -= OnCancelCardThrow;
             _inputActions.Player.FalseTrigger.performed -= OnFalseTriggerPerformed;
             
             _inputActions.Player.Disable();
@@ -104,6 +106,13 @@ namespace _Scripts
                  */
                 Debug.Log("False Trigger Input");
                 OnFalseTrigger?.Invoke();
+        }
+
+        public event Action OnCancelActiveCard;
+        private void OnCancelCardThrow(InputAction.CallbackContext context)
+        {
+            Debug.Log("Cancel throw");
+            OnCancelActiveCard?.Invoke();
         }
     }
 }


### PR DESCRIPTION
- Cancel the active card in the scene with r1 / right bumper / 3
- Directional arrow would appear after a card was thrown until the input was released. Now it disappears as soon as the throw is made