### PR TITLE
Fixed card corner collisions & added safety check for teleport position

### DIFF
--- a/Assets/Prefabs/Card.prefab
+++ b/Assets/Prefabs/Card.prefab
@@ -115,10 +115,10 @@ GameObject:
   m_Component:
   - component: {fileID: 33085085679276533}
   - component: {fileID: 421460074004336576}
-  - component: {fileID: 7506234588005209405}
   - component: {fileID: 7851773646926739524}
   - component: {fileID: 7652606588559616083}
   - component: {fileID: 4688650567464430537}
+  - component: {fileID: 8408566146375188472}
   m_Layer: 7
   m_Name: Card
   m_TagString: Untagged
@@ -159,51 +159,6 @@ MonoBehaviour:
   speed: 20
   totalBounces: 3
   bounces: 0
---- !u!61 &7506234588005209405
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7098434270888417122}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.57, y: 0.48}
-    newSize: {x: 1.57, y: 0.48}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.4, y: 0.4}
-  m_EdgeRadius: 0
 --- !u!50 &7851773646926739524
 Rigidbody2D:
   serializedVersion: 4
@@ -304,3 +259,38 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!58 &8408566146375188472
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7098434270888417122}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.52

--- a/Assets/_Scripts/Card/CardManager.cs
+++ b/Assets/_Scripts/Card/CardManager.cs
@@ -162,7 +162,7 @@ namespace _Scripts.Card
         {
             if (Card.Instance != null)
             {
-                Teleport.Invoke(Card.Instance.transform.position);
+                Teleport.Invoke(Card.Instance.lastSafePosition);
             }
         }
 

--- a/Assets/_Scripts/Card/CardManager.cs
+++ b/Assets/_Scripts/Card/CardManager.cs
@@ -103,7 +103,7 @@ namespace _Scripts.Card
             // Check if the cooldown has passed
             if (Time.time - _lastCardThrowTime <= cooldown)
             {
-                Debug.Log("Card throw is on cooldown.");
+                // Debug.Log("Card throw is on cooldown.");
                 return;
             }
             

--- a/Assets/_Scripts/InputHandler.cs
+++ b/Assets/_Scripts/InputHandler.cs
@@ -92,7 +92,7 @@ namespace _Scripts
         private void OnThrowPerformed(InputAction.CallbackContext context)
         {
             if (PlayerVariables.Instance.stateManager.state == PlayerState.Stunned) return;
-            Debug.Log("Throw Input");
+            // Debug.Log("Throw Input");
             OnCardThrow?.Invoke();
         }
         
@@ -104,14 +104,14 @@ namespace _Scripts
                  * of escaping one regardless if the player already has an active card out and near the enemy.
                  * So, allow FalseTrigger input even if the player is stunned
                  */
-                Debug.Log("False Trigger Input");
+                // Debug.Log("False Trigger Input");
                 OnFalseTrigger?.Invoke();
         }
 
         public event Action OnCancelActiveCard;
         private void OnCancelCardThrow(InputAction.CallbackContext context)
         {
-            Debug.Log("Cancel throw");
+            // Debug.Log("Cancel throw");
             OnCancelActiveCard?.Invoke();
         }
     }

--- a/Assets/_Scripts/Player/PlayerAnimator.cs
+++ b/Assets/_Scripts/Player/PlayerAnimator.cs
@@ -120,13 +120,13 @@ namespace _Scripts.Player
         
         private void OnJumpDown()
         {
-            Debug.Log("Attempting to jump");
+           //  Debug.Log("Attempting to jump");
             _animator.SetBool(Jumping, true);
         }
 
         private void OnLanded()
         {
-            Debug.Log("Landed");
+            // Debug.Log("Landed");
             
             _animator.SetBool(Jumping, false);
         }


### PR DESCRIPTION
#### Card collision fixes:
- Changed from a BoxCollider2D to CircleCollider2D to prevent direct corner impacts
- Casted a ray from the position of the last frame to the position of the current frame looking for environment hits. On hit move the card back to the last frame's position, get the surface normal of the ray hit then reflect and invert if needed
#### Teleportation safety:
Each frame the card is active it now checks around it for obstructions that would overlap with the players collider. If there is no overlap during the current frame it updates its last known safe position. When the call teleport function is called in the card manager it now uses this position instead of the card's transform position.