### PR TITLE
Lowered wall jump cooldown

### DIFF
--- a/Assets/Stat Presets/Player Controller.asset
+++ b/Assets/Stat Presets/Player Controller.asset
@@ -34,7 +34,8 @@ MonoBehaviour:
   DashDuration: 0.1
   DashCooldown: 1.25
   WallSlideSpeed: 2.75
-  WallHangCooldown: 0.525
+  WallHangCooldown: 0.325
+  LedgeHangCooldown: 0.325
   WallCoyoteTime: 0.25
   WallJumpPower: 18
   MaxCrouchSpeed: 4

--- a/Assets/_Scripts/Player/PlayerMovement.cs
+++ b/Assets/_Scripts/Player/PlayerMovement.cs
@@ -412,8 +412,6 @@ namespace _Scripts.Player
          */
         public void WallSlideMovement()
         {
-            
-            var wallSlideSpeed = PlayerVariables.Instance.Stats.WallSlideSpeed;
             _frameVelocity.y = Mathf.MoveTowards(_frameVelocity.y, -PlayerVariables.Instance.Stats.WallSlideSpeed, Time.fixedDeltaTime);
             // _frameVelocity.x = 0f;
         }


### PR DESCRIPTION
Lowered wall jump and ledge hang cooldowns so they feel better to use. Did NOT add a system to prevent players from scaling the same wall.