### PR TITLE
Sin overlap bug is more uncommon

### DIFF
--- a/Assets/_Scripts/GameManager.cs
+++ b/Assets/_Scripts/GameManager.cs
@@ -258,11 +258,10 @@ namespace _Scripts
             }
             
             List<GameObject> potentialSinsToPurge = new List<GameObject>(GameObject.FindGameObjectsWithTag("PotentialSin"));
-            foreach (GameObject potentialSin in potentialSinsToPurge)
+            for (int i = 0; i < potentialSinsToPurge.Count; i++)
             {
-                Destroy(potentialSin);
+                Destroy(potentialSinsToPurge[i]);
             }
-
             activeSins.Clear();
             potentialSins = new List<GameObject>();
         }
@@ -326,6 +325,7 @@ namespace _Scripts
             GameObject potentialSin = potentialSins[location];
             Vector3 sinLocation = potentialSin.transform.position;
             InstantiateSin(weight ,sinLocation);
+            GameObject.Destroy(potentialSins[location]);
             potentialSins.RemoveAt(location);
 
             if (potentialSin is null)
@@ -344,7 +344,7 @@ namespace _Scripts
             GameObject sinToInstantiate;
             switch (weight)
             {
-                case 25: 
+                case < 25: 
                     sinToInstantiate = smallSinPrefab;
                     break;
                 case < 40:


### PR DESCRIPTION
It is still possible to run into the sin overlap bug, but it is much less rare than it used to be. It used to never delete the potential sin location upon being instantiated, allowing for them to generate infinitely on top of each other. Now, it will delete it most of the time, and it is once again possible to run out of potential sin locations. I've played through a few times with the intention of attacking every enemy possible, and I've never gotten more than 2 overlaps