### PR TITLE
Stick wiggle visual fix

### DIFF
--- a/Assets/_Scripts/Enemies/Guard/State/GuardAggroState.cs
+++ b/Assets/_Scripts/Enemies/Guard/State/GuardAggroState.cs
@@ -115,6 +115,7 @@ namespace _Scripts.Enemies.Guard.State
                     PlayerStateManager.Instance.TransitionToState(PlayerStateManager.Instance.FreeMovingState);
 
                 GameManager.Instance.quicktimeEventPanel.SetActive(false);
+                GameManager.Instance.quicktimeEventProgressPanel.SetActive(false);
                 _enemy.StopCoroutine(_qteCoroutine);
                 _qteCoroutine = null;
             }

--- a/Assets/_Scripts/InputHandler.cs
+++ b/Assets/_Scripts/InputHandler.cs
@@ -146,7 +146,7 @@ namespace _Scripts
 
         private void OnThrowPerformed(InputAction.CallbackContext context)
         {
-            if (PlayerStateManager.Instance.IsStunnedState()) return;
+            // if (PlayerStateManager.Instance.IsStunnedState()) return;
             // Debug.Log("Throw Input");
             OnCardThrow?.Invoke();
         }


### PR DESCRIPTION
Disable the stick wiggle canvas on the patroller's exit state to prevent it from remaining on the screen after the qte has ended.

Remove the stunned state check in the input handler to allow the player to teleport to a card if it is already in the scene when in the patroller's qte